### PR TITLE
feature/US15934

### DIFF
--- a/agility.api/src/main/resources/schema/assetProperty.xsd
+++ b/agility.api/src/main/resources/schema/assetProperty.xsd
@@ -89,16 +89,6 @@ REPRODUCTION OF WORKS NOT EXPRESSLY AUTHORIZED BY SERVICEMESH IS STRICTLY PROHIB
             </xsd:annotation>
          </xsd:element>
          
-         <xsd:element name="locked" type="xsd:boolean" default="false">
-            <xsd:annotation>
-               <xsd:appinfo>
-                  <annox:annotate target="field">
-                     <a:ApiField comment="True if the property is to be locked and not allow changes." />
-                  </annox:annotate>
-               </xsd:appinfo>
-            </xsd:annotation>
-         </xsd:element>
-         
          <xsd:element name="propertyType" type="agility:Link" minOccurs="0" maxOccurs="1">
             <xsd:annotation>
                <xsd:appinfo>

--- a/agility.api/src/main/resources/schema/enumerations.xsd
+++ b/agility.api/src/main/resources/schema/enumerations.xsd
@@ -671,7 +671,7 @@ REPRODUCTION OF WORKS NOT EXPRESSLY AUTHORIZED BY SERVICEMESH IS STRICTLY PROHIB
       </xsd:annotation>
       <xsd:restriction base="xsd:string" >
          <xsd:enumeration value="ORDER" />
-         <xsd:enumeration value="PREDEPLOY" />
+         <xsd:enumeration value="DEPLOY" />
          <xsd:enumeration value="POSTDEPLOY" />
       </xsd:restriction>
    </xsd:simpleType>

--- a/agility.api/src/main/resources/schema/enumerations.xsd
+++ b/agility.api/src/main/resources/schema/enumerations.xsd
@@ -658,4 +658,22 @@ REPRODUCTION OF WORKS NOT EXPRESSLY AUTHORIZED BY SERVICEMESH IS STRICTLY PROHIB
       </xsd:restriction>
    </xsd:simpleType>
 
+   <xsd:simpleType name="LockStage" >
+      <xsd:annotation>
+         <xsd:appinfo>
+            <annox:annotate target="class">
+               <jxml:XmlRootElement>
+                  <jxml:name>LockStage</jxml:name>
+               </jxml:XmlRootElement>
+               <a:ApiModel comment="LockStage Enumeration - stage at which asset property should be locked/unlocked." />
+            </annox:annotate>
+         </xsd:appinfo>
+      </xsd:annotation>
+      <xsd:restriction base="xsd:string" >
+         <xsd:enumeration value="ORDER" />
+         <xsd:enumeration value="PREDEPLOY" />
+         <xsd:enumeration value="POSTDEPLOY" />
+      </xsd:restriction>
+   </xsd:simpleType>
+
 </xsd:schema>

--- a/agility.api/src/main/resources/schema/propertyDefinitionStageLock.xsd
+++ b/agility.api/src/main/resources/schema/propertyDefinitionStageLock.xsd
@@ -69,29 +69,4 @@ REPRODUCTION OF WORKS NOT EXPRESSLY AUTHORIZED BY SERVICEMESH IS STRICTLY PROHIB
       </xsd:sequence>
    </xsd:complexType>
 
-   <xsd:complexType name="PropertyDefinitionStageLockList">
-      <xsd:annotation>
-         <xsd:appinfo>
-            <annox:annotate target="class">
-               <jxml:XmlRootElement>
-                  <jxml:name>PropertyDefinitionStageLockList</jxml:name>
-               </jxml:XmlRootElement>
-               <a:ApiModel comment="Container object for PropertyDefinitionStageLock entities." />
-            </annox:annotate>
-         </xsd:appinfo>
-      </xsd:annotation>
-
-		<xsd:sequence>
-           <xsd:element name="stageLock" type="agility:PropertyDefinitionStageLock" minOccurs="0" maxOccurs="unbounded">
-		      <xsd:annotation>
-		         <xsd:appinfo>
-		            <annox:annotate target="field">
-		               <a:ApiField comment="List of PropertyDefinitionStageLock objects that identify lock behavior of a property definition at a particular stage." />
-		            </annox:annotate>
-		         </xsd:appinfo>
-		      </xsd:annotation>
-		   </xsd:element>
-		</xsd:sequence>
-   </xsd:complexType>
-
 </xsd:schema>

--- a/agility.api/src/main/resources/schema/propertyDefinitionStageLock.xsd
+++ b/agility.api/src/main/resources/schema/propertyDefinitionStageLock.xsd
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+COPYRIGHT (C) 2008-2017 DXC Technology, INC.  ALL RIGHTS RESERVED.  CONFIDENTIAL AND PROPRIETARY. 
+ 
+ALL SOFTWARE, INFORMATION AND ANY OTHER RELATED COMMUNICATIONS (COLLECTIVELY, "WORKS") ARE CONFIDENTIAL AND PROPRIETARY 
+INFORMATION THAT ARE THE EXCLUSIVE PROPERTY OF SERVICEMESH.     ALL WORKS ARE PROVIDED UNDER THE APPLICABLE AGREEMENT OR 
+END USER LICENSE AGREEMENT IN EFFECT BETWEEN YOU AND SERVICEMESH.  UNLESS OTHERWISE SPECIFIED IN THE APPLICABLE AGREEMENT, 
+ALL WORKS ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, 
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.  ALL USE, DISCLOSURE AND/OR 
+REPRODUCTION OF WORKS NOT EXPRESSLY AUTHORIZED BY SERVICEMESH IS STRICTLY PROHIBITED.
+-->
+
+<xsd:schema targetNamespace="http://servicemesh.com/agility/api"
+   xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="qualified"
+   xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.0" jaxb:extensionBindingPrefixes="xjc annox"
+   xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+   xmlns:annox="http://annox.dev.java.net" 
+   xmlns:a="http://annox.dev.java.net/com.servicemesh.agility.tools.annotation"
+   xmlns:jl="http://annox.dev.java.net/java.lang"
+   xmlns:jxml="http://annox.dev.java.net/javax.xml.bind.annotation"
+   xmlns:agility="http://servicemesh.com/agility/api">
+
+   <xsd:include schemaLocation="enumerations.xsd" />
+     
+   <xsd:complexType name="PropertyDefinitionStageLock">
+      <xsd:annotation>
+         <xsd:appinfo>
+            <annox:annotate target="class">
+               <jxml:XmlRootElement>
+                  <jxml:name>PropertyDefinitionStageLock</jxml:name>
+               </jxml:XmlRootElement>
+               <a:ApiModel comment="Property definition stage lock entity." 
+                           description = "Identifies the lock behavior of a property definition at a particular lifecycle stage." 
+                           externalDocLink = "" />
+            </annox:annotate>
+         </xsd:appinfo>
+      </xsd:annotation>
+      <xsd:sequence>
+         <xsd:element name="propDefId" type="xsd:integer" minOccurs="1">
+            <xsd:annotation>
+               <xsd:appinfo>
+                  <annox:annotate target="field">
+                     <a:ApiField comment="Identifier of property definition object.  Foreign key reference to property definition." />
+                  </annox:annotate>
+               </xsd:appinfo>
+            </xsd:annotation>
+         </xsd:element>
+               
+         <xsd:element name="stage" type="agility:LockStage" minOccurs="1">
+            <xsd:annotation>
+               <xsd:appinfo>
+                  <annox:annotate target="field">
+                     <a:ApiField comment="Name of stage to which a lock status will be assigned." />
+                  </annox:annotate>
+               </xsd:appinfo>
+            </xsd:annotation>
+         </xsd:element>
+               
+         <xsd:element name="locked" type="xsd:boolean" default="false">
+            <xsd:annotation>
+               <xsd:appinfo>
+                  <annox:annotate target="field">
+                     <a:ApiField comment="When true, the property definition (asset property) will be locked at this stage.  Default is false." />
+                  </annox:annotate>
+               </xsd:appinfo>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
+
+   <xsd:complexType name="PropertyDefinitionStageLockList">
+      <xsd:annotation>
+         <xsd:appinfo>
+            <annox:annotate target="class">
+               <jxml:XmlRootElement>
+                  <jxml:name>PropertyDefinitionStageLockList</jxml:name>
+               </jxml:XmlRootElement>
+               <a:ApiModel comment="Container object for PropertyDefinitionStageLock entities." />
+            </annox:annotate>
+         </xsd:appinfo>
+      </xsd:annotation>
+
+		<xsd:sequence>
+           <xsd:element name="stageLock" type="agility:PropertyDefinitionStageLock" minOccurs="0" maxOccurs="unbounded">
+		      <xsd:annotation>
+		         <xsd:appinfo>
+		            <annox:annotate target="field">
+		               <a:ApiField comment="List of PropertyDefinitionStageLock objects that identify lock behavior of a property definition at a particular stage." />
+		            </annox:annotate>
+		         </xsd:appinfo>
+		      </xsd:annotation>
+		   </xsd:element>
+		</xsd:sequence>
+   </xsd:complexType>
+
+</xsd:schema>

--- a/agility.api/src/main/resources/schema/propertyDefinitionStageLock.xsd
+++ b/agility.api/src/main/resources/schema/propertyDefinitionStageLock.xsd
@@ -31,7 +31,7 @@ REPRODUCTION OF WORKS NOT EXPRESSLY AUTHORIZED BY SERVICEMESH IS STRICTLY PROHIB
                   <jxml:name>PropertyDefinitionStageLock</jxml:name>
                </jxml:XmlRootElement>
                <a:ApiModel comment="Property definition stage lock entity." 
-                           description = "Identifies the lock behavior of a property definition at a particular lifecycle stage." 
+                           description = "Identifies the lock behavior of a property definition at a particular lifecycle stage.  This does not mean it is locked, it means the UI should disable editing capability at the stage." 
                            externalDocLink = "" />
             </annox:annotate>
          </xsd:appinfo>
@@ -51,7 +51,7 @@ REPRODUCTION OF WORKS NOT EXPRESSLY AUTHORIZED BY SERVICEMESH IS STRICTLY PROHIB
             <xsd:annotation>
                <xsd:appinfo>
                   <annox:annotate target="field">
-                     <a:ApiField comment="Name of stage to which a lock status will be assigned." />
+                     <a:ApiField comment="Name of stage to which a lock status behavior is assigned." />
                   </annox:annotate>
                </xsd:appinfo>
             </xsd:annotation>
@@ -61,7 +61,7 @@ REPRODUCTION OF WORKS NOT EXPRESSLY AUTHORIZED BY SERVICEMESH IS STRICTLY PROHIB
             <xsd:annotation>
                <xsd:appinfo>
                   <annox:annotate target="field">
-                     <a:ApiField comment="When true, the property definition (asset property) will be locked at this stage.  Default is false." />
+                     <a:ApiField comment="When true, the property definition (asset property) behavior at this stage is uneditable in the UI.  Default is false." />
                   </annox:annotate>
                </xsd:appinfo>
             </xsd:annotation>


### PR DESCRIPTION


This ticket wants to add lock behavior for property definitions at certain lifecycle stages.  This only applies to the StoreLaunchItem asset type and its subtypes.

- I create a new enum for the defined stages.
- I create a new table to store the data.  This table is linked to the property definition table.
- The intent is to add a new attribute to the PropertyDefinition which is a list of stage locks.  It should be empty for all asset types except those listed above.
- The data will be managed by property definition saves/updates, i.e. no API for loading this
