### PR TITLE
SNB-3928 Add CI attributes to Agility Assets

### DIFF
--- a/agility.api/src/main/resources/schema/asset.xsd
+++ b/agility.api/src/main/resources/schema/asset.xsd
@@ -271,6 +271,36 @@ REPRODUCTION OF WORKS NOT EXPRESSLY AUTHORIZED BY SERVICEMESH IS STRICTLY PROHIB
                </xsd:appinfo>
             </xsd:annotation>
          </xsd:element>
+         
+         <xsd:element name="correlationId" type="xsd:string" minOccurs="0">
+            <xsd:annotation>
+               <xsd:appinfo>
+                  <annox:annotate target="field">
+                     <a:ApiField comment="Unique identifier in cloud or other forien system." introducedIn="4.0" />
+                  </annox:annotate>
+               </xsd:appinfo>
+            </xsd:annotation>
+         </xsd:element>
+         
+         <xsd:element name="ciSysId" type="xsd:string" minOccurs="0">
+            <xsd:annotation>
+               <xsd:appinfo>
+                  <annox:annotate target="field">
+                     <a:ApiField comment="Related Configuration Item ID" introducedIn="4.0" />
+                  </annox:annotate>
+               </xsd:appinfo>
+            </xsd:annotation>
+         </xsd:element>
+         
+         <xsd:element name="ciSysName" type="xsd:string" minOccurs="0">
+            <xsd:annotation>
+               <xsd:appinfo>
+                  <annox:annotate target="field">
+                     <a:ApiField comment="Related Configuration Item name" introducedIn="4.0" />
+                  </annox:annotate>
+               </xsd:appinfo>
+            </xsd:annotation>
+         </xsd:element>         
 
       </xsd:sequence>
       </xsd:extension>


### PR DESCRIPTION
This allows any asset in Agility be be linked to a PDXC CI so that operations like Incident, Change, etc. can be done on that asset.